### PR TITLE
Initial version for adding typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ node_modules
 susy-test/
 examples/bundle.js
 dist/
+
+typings

--- a/react-responsive-grid.d.ts
+++ b/react-responsive-grid.d.ts
@@ -1,0 +1,36 @@
+import {Component} from 'react'
+
+interface ContainerProps {
+  children?: any
+  style?: Object
+}
+
+export class Container extends Component<ContainerProps, {}> {}
+
+interface GridProps {
+  columns?: number
+  gutterRatio?: number
+}
+
+export class Grid extends Component<GridProps, {}> {}
+
+interface SpanProps {
+  context?: Object
+  columns?: number
+  at?: number
+  pre?: number
+  post?: number
+  squish?: number
+  last?: boolean
+  break?: boolean
+}
+
+export class Span extends Component<SpanProps, {}> {}
+
+interface BreakpointProps {
+  widthMethod: string
+  minWidth?: number
+  maxWidth?: number
+}
+
+export class Breakpoint extends Component<BreakpointProps, {}> {}

--- a/typings.json
+++ b/typings.json
@@ -1,0 +1,7 @@
+{
+  "name": "react-responsive-grid",
+  "main": "react-responsive-grid.d.ts",
+  "globalDependencies": {
+    "react": "registry:dt/react#0.14.0+20160526134601"
+  }
+}


### PR DESCRIPTION
I think this should be a working version for #9 

`typings install github:bali182/react-responsive-grid#9e4a1a64c749446588089c6d1ca16a147c9f5478 --save`

Ran successfully, but the output was:

> typings INFO globaldependencies "undefined" lists global dependencies on "react" and should be installed
> react-responsive-grid
> └── (No dependencies)

No idea what this means. Regardless, after the installation this worked:

``` ts
/// <reference path="typings/index.d.ts"/>

import {Grid} from 'react-responsive-grid'
```

And atom-typescript could navigate to the appropriate definition, when I pressed F12 on `Grid`
