### PR TITLE
Use 'createReactClass' instead of 'React.createClass'

### DIFF
--- a/examples/ChildSpans.cjsx
+++ b/examples/ChildSpans.cjsx
@@ -1,7 +1,8 @@
 React = require 'react'
 {Container, Grid, Breakpoint, Span} = require '../src/index'
+createReactClass = require 'create-react-class'
 
-module.exports = React.createClass
+module.exports = createReactClass
   render: ->
     <div>
       <h2>Child spans</h2>

--- a/examples/ComplexResponsiveLayout.cjsx
+++ b/examples/ComplexResponsiveLayout.cjsx
@@ -1,5 +1,6 @@
 React = require 'react'
 {Container, Grid, Breakpoint, Span} = require '../src/index'
+createReactClass = require 'create-react-class'
 
 purpleStyle =
   border: '2px solid purple'
@@ -10,7 +11,7 @@ purpleStyle =
   marginBottom: '1rem'
   textAlign: 'center'
 
-module.exports = React.createClass
+module.exports = createReactClass
   render: ->
     <div>
       <h2>More complex layout taken from http://www.zell-weekeat.com/smarter-layouts-with-susy/</h2>

--- a/examples/Controls.cjsx
+++ b/examples/Controls.cjsx
@@ -1,7 +1,8 @@
 React = require 'react'
 {Link} = require 'react-router'
+createReactClass = require 'create-react-class'
 
-module.exports = React.createClass
+module.exports = createReactClass
   render: ->
     <ul>
       <li><Link to="/">Introduction</Link></li>

--- a/examples/Intro.cjsx
+++ b/examples/Intro.cjsx
@@ -1,6 +1,7 @@
 React = require 'react'
+createReactClass = require 'create-react-class'
 
-module.exports = React.createClass
+module.exports = createReactClass
   render: ->
     <div>
       <h1>React Responsive Grid</h1>

--- a/examples/PrePostSquish.cjsx
+++ b/examples/PrePostSquish.cjsx
@@ -1,5 +1,6 @@
 React = require 'react'
 {Container, Grid, Breakpoint, Span} = require '../src/index'
+createReactClass = require 'create-react-class'
 
 purpleStyle =
   border: '2px solid purple'
@@ -10,7 +11,7 @@ purpleStyle =
   marginBottom: '1rem'
   textAlign: 'center'
 
-module.exports = React.createClass
+module.exports = createReactClass
   render: ->
     <div>
       <h2>Demo squish, post, pre</h2>

--- a/examples/Router.cjsx
+++ b/examples/Router.cjsx
@@ -2,6 +2,7 @@ React = require 'react'
 {render} = require 'react-dom'
 {browserHistory, Router, Route, IndexRoute}  = require 'react-router'
 {Container, Grid, Breakpoint, Span} = require '../src/index'
+createReactClass = require 'create-react-class'
 
 Typography = require 'typography'
 typography = Typography()
@@ -11,7 +12,7 @@ injectStyles()
 Controls = require './Controls'
 Intro = require './Intro'
 
-App = React.createClass
+App = createReactClass
   render: ->
     <div>
       <div style={{

--- a/examples/ThreeColumn.cjsx
+++ b/examples/ThreeColumn.cjsx
@@ -1,8 +1,9 @@
 React = require 'react'
 faker = require 'faker'
 {Container, Grid, Breakpoint, Span} = require '../src/index'
+createReactClass = require 'create-react-class'
 
-module.exports = React.createClass
+module.exports = createReactClass
   render: ->
     <div>
       <h2>Simple three column layout</h2>

--- a/examples/TwoColumn.cjsx
+++ b/examples/TwoColumn.cjsx
@@ -1,8 +1,9 @@
 React = require 'react'
 faker = require 'faker'
 {Container, Grid, Breakpoint, Span} = require '../src/index'
+createReactClass = require 'create-react-class'
 
-module.exports = React.createClass
+module.exports = createReactClass
   render: ->
     <div>
       <h2>Responsive two column layout</h2>

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/KyleAMathews/react-responsive-grid/issues"
   },
   "dependencies": {
+    "create-react-class": "^15.6.3",
     "object-assign": "^4.0.1",
     "react-component-width-mixin": "^2.0.0",
     "react-page-width": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "create-react-class": "^15.6.3",
     "object-assign": "^4.0.1",
+    "prop-types": "^15.6.2",
     "react-component-width-mixin": "^2.0.0",
     "react-page-width": "^1.0.1"
   },

--- a/src/components/Breakpoint.cjsx
+++ b/src/components/Breakpoint.cjsx
@@ -2,8 +2,9 @@ React = require 'react'
 componentWidthMixin = require 'react-component-width-mixin'
 PageWidthMixin = require 'react-page-width'
 objectAssign = require 'object-assign'
+createReactClass = require 'create-react-class'
 
-ComponentWidthComponent = React.createClass
+ComponentWidthComponent = createReactClass
   displayName: "Breakpoint"
 
   mixins: [componentWidthMixin]
@@ -42,7 +43,7 @@ ComponentWidthComponent = React.createClass
     else
       return <div />
 
-PageWidthComponent = React.createClass
+PageWidthComponent = createReactClass
   displayName: "Breakpoint"
 
   mixins: [PageWidthMixin]
@@ -81,7 +82,7 @@ PageWidthComponent = React.createClass
     else
       return <div />
 
-module.exports = React.createClass
+module.exports = createReactClass
   displayName: 'Breakpoint'
 
   propTypes:

--- a/src/components/Breakpoint.cjsx
+++ b/src/components/Breakpoint.cjsx
@@ -3,6 +3,7 @@ componentWidthMixin = require 'react-component-width-mixin'
 PageWidthMixin = require 'react-page-width'
 objectAssign = require 'object-assign'
 createReactClass = require 'create-react-class'
+PropTypes = require 'prop-types'
 
 ComponentWidthComponent = createReactClass
   displayName: "Breakpoint"
@@ -10,8 +11,8 @@ ComponentWidthComponent = createReactClass
   mixins: [componentWidthMixin]
 
   propTypes:
-    minWidth: React.PropTypes.number
-    maxWidth: React.PropTypes.number
+    minWidth: PropTypes.number
+    maxWidth: PropTypes.number
 
   getDefaultProps: ->
     {
@@ -49,8 +50,8 @@ PageWidthComponent = createReactClass
   mixins: [PageWidthMixin]
 
   propTypes:
-    minWidth: React.PropTypes.number
-    maxWidth: React.PropTypes.number
+    minWidth: PropTypes.number
+    maxWidth: PropTypes.number
 
   getDefaultProps: ->
     {
@@ -86,9 +87,9 @@ module.exports = createReactClass
   displayName: 'Breakpoint'
 
   propTypes:
-    widthMethod: React.PropTypes.string.isRequired
-    minWidth: React.PropTypes.number
-    maxWidth: React.PropTypes.number
+    widthMethod: PropTypes.string.isRequired
+    minWidth: PropTypes.number
+    maxWidth: PropTypes.number
 
   getDefaultProps: ->
     widthMethod: 'pageWidth'

--- a/src/components/Container.cjsx
+++ b/src/components/Container.cjsx
@@ -1,7 +1,8 @@
 React = require 'react'
 objectAssign = require('object-assign')
+createReactClass = require 'create-react-class'
 
-module.exports = React.createClass
+module.exports = createReactClass
   displayName: "Container"
 
   render: ->

--- a/src/components/Grid.cjsx
+++ b/src/components/Grid.cjsx
@@ -1,13 +1,14 @@
 React = require 'react'
 objectAssign = require('object-assign')
 createReactClass = require 'create-react-class'
+PropTypes = require 'prop-types'
 
 module.exports = createReactClass
   displayName: "Grid"
 
   propTypes:
-    columns: React.PropTypes.number
-    gutterRatio: React.PropTypes.number
+    columns: PropTypes.number
+    gutterRatio: PropTypes.number
 
   getDefaultProps: ->
     {

--- a/src/components/Grid.cjsx
+++ b/src/components/Grid.cjsx
@@ -1,7 +1,8 @@
 React = require 'react'
 objectAssign = require('object-assign')
+createReactClass = require 'create-react-class'
 
-module.exports = React.createClass
+module.exports = createReactClass
   displayName: "Grid"
 
   propTypes:

--- a/src/components/Span.cjsx
+++ b/src/components/Span.cjsx
@@ -1,9 +1,10 @@
 React = require 'react'
 objectAssign = require('object-assign')
+createReactClass = require 'create-react-class'
 
 spanCalculate = require '../utils/SpanCalculate'
 
-module.exports = React.createClass
+module.exports = createReactClass
   displayName: "Span"
 
   propTypes:

--- a/src/components/Span.cjsx
+++ b/src/components/Span.cjsx
@@ -1,6 +1,7 @@
 React = require 'react'
 objectAssign = require('object-assign')
 createReactClass = require 'create-react-class'
+PropTypes = require 'prop-types'
 
 spanCalculate = require '../utils/SpanCalculate'
 
@@ -8,14 +9,14 @@ module.exports = createReactClass
   displayName: "Span"
 
   propTypes:
-    context: React.PropTypes.object
-    columns: React.PropTypes.number
-    at: React.PropTypes.number
-    pre: React.PropTypes.number
-    post: React.PropTypes.number
-    squish: React.PropTypes.number
-    last: React.PropTypes.bool
-    break: React.PropTypes.bool
+    context: PropTypes.object
+    columns: PropTypes.number
+    at: PropTypes.number
+    pre: PropTypes.number
+    post: PropTypes.number
+    squish: PropTypes.number
+    last: PropTypes.bool
+    break: PropTypes.bool
 
   getDefaultProps: ->
     at: 0


### PR DESCRIPTION
Resolves #16 

`React.createClass` was removed in React 16
